### PR TITLE
前言Node链接修复，1.4代码块显示优化以及增加测试部分解释

### DIFF
--- a/src/1/1.4.md
+++ b/src/1/1.4.md
@@ -24,7 +24,7 @@
 
 这是npm默认创建的package.json，此时并没有配置ES模块信息。需要手动编写，增加"type": "module"。此时，package.json文件内容如下。
 
-```bash
+```json
 {
   "name": "helloworld",
   "version": "1.0.0",
@@ -44,7 +44,7 @@
 
 为了演示方便，我们采用之前的代码。
 
-```bash
+```javascript
 // 定义一个异步函数
 async function sayHi(name) {
   try {
@@ -90,7 +90,7 @@ $ node index.js alfred
 
 修改package.json如下
 
-```bash
+```json
 {
   "name": "node-v20-helloworld",
   "version": "1.0.5",
@@ -144,10 +144,9 @@ Node.js遵循与JavaScript本身相同的"最小核心"原则。因此，像代�
 
 在Node.js v18开始内置了测试框架，在Node.js v20版本中，已经被标记为Stable能力，大家可以放心使用。
 
-使用Node.js 内置的测试框架，测试代码如下。
+我们可以创建一个`index.test.js`文件，文件里的测试代码如下。
 
-```bash
-
+```javascript
 import { test } from "node:test";
 import assert from "node:assert";
 
@@ -163,15 +162,22 @@ test("test if works correctly", function (t) {
   assert.strictEqual(log.mock.callCount(), 1);
 });
 ```
+由于我们在测试代码文件引入了`index.js`中的`sayHi`，因此要在`index.js`文件中给该函数加上`export`
+
+```javascript
+export async function sayHi(name) {
+  ...
+}
+```
 
 在package.json中修改npm scripts
 
-```bash
+```json
 "scripts": {
     "test": "node --test"
 },
 ```
-
+其中`--test`命令行标志指示Node.js自动寻找以`.test.js`为结尾的文件，并执行其中的测试代码。
 执行测试结果如下。
 
 ```bash
@@ -231,12 +237,12 @@ Hello liangqi!
 
 后经过排查，发现sayHi是Async函数，在测试方法里，没有使用await来对接。需要修改2处。
 
-- test("test if works correctly", async function (t) {})，第二个参数，需要修噶以为Async函数，这是因为await外层必须是async函数。
+- test("test if works correctly", async function (t) {})，第二个参数，需要修改为Async函数，这是因为await外层必须是async函数。
 - sayHi("liangqi") 方法需要改成await sayHi("liangqi")，这样异步方法就转换为同步方法了。
 
 将代码修改如下
 
-```bash
+```javascript
 import { test } from "node:test";
 import assert from "node:assert";
 
@@ -305,7 +311,7 @@ $ npm i --save node-v20-helloworld
 
 调用代码如下，一定要注意await，上面测试部分有见过坑，不可偷懒。
 
-```bash
+```javascript
 #! /usr/bin/env node
 import { sayHi } from 'node-v20-helloworld';
 

--- a/src/preface.md
+++ b/src/preface.md
@@ -14,17 +14,17 @@ AI时代放大了全栈的好处，很多以前我们觉得可以吃饭的一些
 
 ## Node.js v20的新特性
 
-- [V8(5.8→11.3) eventloop promise-base api（error-first） event npm](prepreface.md#)
-- [ESM](prepreface.md#)
-- [async/await + promise + hooks](prepreface.md#)
-- [worker thread（tinypool）](prepreface.md#)
-- [loader、network-import](prepreface.md#)
-- [test runner](prepreface.md#)
-- [权限模型](prepreface.md#)
-- [可观测性，包括 logging/metrics/tracing，以及 APM 等](prepreface.md#)
-- [现代化的 HTTP：undici](prepreface.md#)
-- [WASM](prepreface.md#)
-- [N-API](prepreface.md#)
+- [V8(5.8→11.3) eventloop promise-base api（error-first） event npm](https://nodejs.cn/en/learn/asynchronous-work/event-loop-timers-and-nexttick)
+- [ESM](https://nodejs.cn/docs/latest-v22.x/api/esm.html#%E6%A8%A1%E5%9D%97ecmascript-%E6%A8%A1%E5%9D%97)
+- [async/await + promise + hooks](https://nodejs.cn/docs/latest-v22.x/api/async_hooks.html#%E5%BC%82%E6%AD%A5%E9%92%A9%E5%AD%90)
+- [worker thread（tinypool）](https://nodejs.cn/docs/latest-v22.x/api/worker_threads.html#worker-threads)
+- [loader、network-import](https://nodejs.cn/docs/latest-v22.x/api/module.html#import-from-https)
+- [test runner](https://nodejs.cn/docs/latest-v22.x/api/test.html#test-runner)
+- [权限模型](https://nodejs.cn/docs/latest-v22.x/api/permissions.html#%E6%9D%83%E9%99%90%E6%A8%A1%E5%9E%8B)
+- [可观测性，包括 logging/metrics/tracing，以及 APM 等](https://nodejs.cn/api/util.html)
+- [现代化的 HTTP：undici](https://undici.nodejs.org/#/)
+- [WASM](https://nodejs.cn/en/learn/getting-started/nodejs-with-webassembly)
+- [N-API](https://nodejs.cn/api/n-api.html)
 
 除了第一条没变外，其他的差异还是蛮大的。差异如此大，目前还没有课程能够系统的进行讲解，这是我觉得非常可惜的，所以本课程后续也会持续的完善。
 


### PR DESCRIPTION
您好，这个PR包含以下几个方面的改动：

- 前言部分：
  - Node v20新增特性对应的链接修复，和之前的一致： #18 ；
- 1.4章节：
  - 给JavaScript和JSON代码块更新了对应的markdown标识，优化代码在网页的高亮提示；
  - 增加了对`node --test`命令的解释，以及提示读者创建新的`index.test.js`来编写与运行测试代码；
  - 提示读者给`index.js`中的`sayHi`函数加上export，以保证测试文件以及模块可以顺利调用该函数；

有修改不对的地方烦请指正，谢谢！