### PR TITLE
fix: 2.3 链接，代码块渲染修复，编号列表格式统一

### DIFF
--- a/src/2/2.3.md
+++ b/src/2/2.3.md
@@ -16,245 +16,243 @@
 
 1. 类型注解：TypeScript可以为变量、函数参数、函数返回值等添加类型注解，以指定它们的数据类型。例如：
 
-```tsx
-let age: number = 25;
-function add(a: number, b: number): number {
-  return a + b;
-}
+    ```ts
+    let age: number = 25;
+    function add(a: number, b: number): number {
+      return a + b;
+    }
+    ```
 
-```
+2. 接口：TypeScript支持接口的定义，用于描述对象的结构和行为。接口可以定义属性、方法、可选属性、只读属性等。例如：
 
-1. 接口：TypeScript支持接口的定义，用于描述对象的结构和行为。接口可以定义属性、方法、可选属性、只读属性等。例如：
+    ```ts
+    interface Person {
+      name: string;
+      age: number;
+      sayHello(): void;
+    }
+    ```
 
-```tsx
-interface Person {
-  name: string;
-  age: number;
-  sayHello(): void;
-}
+3. 泛型：TypeScript支持泛型，用于创建可重用的、类型安全的代码。泛型可以在函数、类、接口中使用，以实现对不同类型的支持。例如：
 
-```
+    ```ts
+    function identity<T>(arg: T): T {
+      return arg;
+    }
+    let result = identity<number>(10);
+    ```
 
-1. 泛型：TypeScript支持泛型，用于创建可重用的、类型安全的代码。泛型可以在函数、类、接口中使用，以实现对不同类型的支持。例如：
+4. 类型别名和联合类型：TypeScript支持类型别名，用于给一个类型起一个新的名字。它还支持联合类型，用于指定一个变量可以是多个类型中的一个。例如：
 
-```tsx
-function identity<T>(arg: T): T {
-  return arg;
-}
-let result = identity<number>(10);
-```
+    ```ts
+    type Point = {
+      x: number;
+      y: number;
+    };
+    type Shape = Circle | Rectangle | Triangle;
+    ```
 
-1. 类型别名和联合类型：TypeScript支持类型别名，用于给一个类型起一个新的名字。它还支持联合类型，用于指定一个变量可以是多个类型中的一个。例如：
+5. 枚举：TypeScript支持枚举类型，用于定义一组具名的常量。枚举类型可以是数字枚举或字符串枚举。例如：
 
-```tsx
-type Point = {
-  x: number;
-  y: number;
-};
-type Shape = Circle | Rectangle | Triangle;
-```
-
-1. 枚举：TypeScript支持枚举类型，用于定义一组具名的常量。枚举类型可以是数字枚举或字符串枚举。例如：
-
-```tsx
-enum Color {
-  Red,
-  Green,
-  Blue
-}
-let color: Color = Color.Red;
-```
+    ```ts
+    enum Color {
+      Red,
+      Green,
+      Blue
+    }
+    let color: Color = Color.Red;
+    ```
 
 这些是TypeScript独有的一些语法和特性，它们使得TypeScript相比于JavaScript具有更强大的类型检查和面向对象编程的能力。通过使用这些特性，开发者可以更好地组织和管理代码，提高代码的可维护性和可读性。
 
 为了让大家能更好地理解并掌握 TypeScript 内置类型别名，我们先来介绍一下相关的一些基础知识。
 
-1、**typeof**
+1. **typeof**
 
-在 TypeScript 中，`typeof` 操作符可以用来获取一个变量声明或对象的类型。
+    在 TypeScript 中，`typeof` 操作符可以用来获取一个变量声明或对象的类型。
 
-```ts
-interface Person {
-  name: string;
-  age: number;
-}
+    ```ts
+    interface Person {
+      name: string;
+      age: number;
+    }
 
-const sem: Person = { name: 'semlinker', age: 30 };
-type Sem= typeof sem;// -> Person
+    const sem: Person = { name: 'semlinker', age: 30 };
+    type Sem= typeof sem;// -> Person
 
-function toArray(x: number): Array<number> {
-  return [x];
-}
+    function toArray(x: number): Array<number> {
+      return [x];
+    }
 
-type Func = typeof toArray;// -> (x: number) => number[]
-```
+    type Func = typeof toArray;// -> (x: number) => number[]
+    ```
 
-2、**keyof**
+2. **keyof**
 
-`keyof` 操作符可以用来一个对象中的所有 key 值：
+    `keyof` 操作符可以用来一个对象中的所有 key 值：
 
-```ts
-interface Person {
- name: string;
- age: number;
-}
+    ```ts
+    interface Person {
+    name: string;
+    age: number;
+    }
 
-type K1 = keyof Person;// "name" | "age"
-type K2 = keyof Person[];// "length" | "toString" | "pop" | "push" | "concat" | "join"
-type K3 = keyof { [x: string]: Person };// string | number
-```
+    type K1 = keyof Person;// "name" | "age"
+    type K2 = keyof Person[];// "length" | "toString" | "pop" | "push" | "concat" | "join"
+    type K3 = keyof { [x: string]: Person };// string | number
+    ```
 
-3、**in**
+3. **in**
 
-`in` 用来遍历枚举类型：
+    `in` 用来遍历枚举类型：
 
-```ts
-type Keys = "a" | "b" | "c"
+    ```ts
+    type Keys = "a" | "b" | "c"
 
-type Obj =  {
-  [p in Keys]: any
-}// -> { a: any, b: any, c: any }
-```
+    type Obj =  {
+      [p in Keys]: any
+    }// -> { a: any, b: any, c: any }
+    ```
 
-4、**infer**
+4. **infer**
 
-在条件类型语句中，可以用 `infer` 声明一个类型变量并且对它进行使用。
+    在条件类型语句中，可以用 `infer` 声明一个类型变量并且对它进行使用。
 
-```ts
-type ReturnType<T> = T extends (
-  ...args: any[]
-) => infer R ? R : any;
-```
+    ```ts
+    type ReturnType<T> = T extends (
+      ...args: any[]
+    ) => infer R ? R : any;
+    ```
 
-以上代码中 `infer R` 就是声明一个变量来承载传入函数签名的返回值类型，简单说就是用它取到函数返回值的类型方便之后使用。
+    以上代码中 `infer R` 就是声明一个变量来承载传入函数签名的返回值类型，简单说就是用它取到函数返回值的类型方便之后使用。
 
-结合下面这种例子，比如容易理解，提取数组的类型。
+    结合下面这种例子，比如容易理解，提取数组的类型。
 
-```tsx
-type T0 = string[];
-type T1 = number[];
+    ```ts
+    type T0 = string[];
+    type T1 = number[];
 
-type UnpackedArray<T> = T extends (infer U)[] ? U : T
-type U0 = UnpackedArray<T1> // number
+    type UnpackedArray<T> = T extends (infer U)[] ? U : T
+    type U0 = UnpackedArray<T1> // number
 
-let a:U0 = 1
-```
+    let a:U0 = 1
+    ```
 
-变化一下，如果UnpackedArray参数没有类型，此时的a就1或2，这就是T存在的意义的。
+    变化一下，如果UnpackedArray参数没有类型，此时的a就1或2，这就是T存在的意义的。
 
-```tsx
-type T0 = string[];
-type T1 = number[];
-type T2 = [1,2];
+    ```ts
+    type T0 = string[];
+    type T1 = number[];
+    type T2 = [1,2];
 
-type UnpackedArray<T> = T extends (infer U)[] ? U : T
-type U0 = UnpackedArray<T2> // number
+    type UnpackedArray<T> = T extends (infer U)[] ? U : T
+    type U0 = UnpackedArray<T2> // number
 
-let a:U0 = 1
-```
+    let a:U0 = 1
+    ```
 
-提取数组里的第一个元素，也可以这样做。
+    提取数组里的第一个元素，也可以这样做。
 
-```tsx
-type First<T extends any[]> = T extends [infer A, ...infer test] ? A : never;
-```
+    ```ts
+    type First<T extends any[]> = T extends [infer A, ...infer test] ? A : never;
+    ```
 
-还有更复杂的例子，简单的Includes
+    还有更复杂的例子，简单的Includes
 
-```tsx
-type Includes<T extends readonly any[], U> = U extends T[number] ? true : false;
-```
+    ```ts
+    type Includes<T extends readonly any[], U> = U extends T[number] ? true : false;
+    ```
 
-![Untitled](img/Untitled%2013.png)
+    ![Untitled](img/Untitled%2013.png)
 
-如果数组里，含有对象、数组呢？通过 extends + infer + rest + recursive 可以 loop Tuple 返回一个 Type。
+    如果数组里，含有对象、数组呢？通过 extends + infer + rest + recursive 可以 loop Tuple 返回一个 Type。
 
-```tsx
-type Includes<T extends readonly any[], U> = T extends [infer First, ...infer Rest]
-? Equal<U, First> extends true
-  ? true
-  : Includes<Rest, U>
-: false;
-```
+    ```ts
+    type Includes<T extends readonly any[], U> = T extends [infer First, ...infer Rest]
+    ? Equal<U, First> extends true
+      ? true
+      : Includes<Rest, U>
+    : false;
+    ```
 
-这样玩下去就很有意思了
+    这样玩下去就很有意思了
 
-5、**extends**
+5. **extends**
 
-有时候我们定义的泛型不想过于灵活或者说想继承某些类等，可以通过 extends 关键字添加泛型约束。
+    有时候我们定义的泛型不想过于灵活或者说想继承某些类等，可以通过 extends 关键字添加泛型约束。
 
-```ts
-interface ILengthwise {
-  length: number;
-}
+    ```ts
+    interface ILengthwise {
+      length: number;
+    }
 
-function loggingIdentity<T extends ILengthwise>(arg: T): T {
-  console.log(arg.length);
-  return arg;
-}
-```
+    function loggingIdentity<T extends ILengthwise>(arg: T): T {
+      console.log(arg.length);
+      return arg;
+    }
+    ```
 
-现在这个泛型函数被定义了约束，因此它不再是适用于任意类型：
+    现在这个泛型函数被定义了约束，因此它不再是适用于任意类型：
 
-```ts
-loggingIdentity(3);// Error, number doesn't have a .length property
-```
+    ```ts
+    loggingIdentity(3);// Error, number doesn't have a .length property
+    ```
 
-这时我们需要传入符合约束类型的值，必须包含必须的属性：
+    这时我们需要传入符合约束类型的值，必须包含必须的属性：
 
-```ts
-loggingIdentity({length: 10, value: 3});
-```
+    ```ts
+    loggingIdentity({length: 10, value: 3});
+    ```
 
-掌握了这些内容，再看一些[https://github.com/type-challenges/type-challenges/blob/main/utils/index.d.ts](https://github.com/type-challenges/type-challenges/blob/main/utils/index.d.ts)就容易多了
+    掌握了这些内容，再看一些[https://github.com/type-challenges/type-challenges/blob/main/utils/index.d.ts](https://github.com/type-challenges/type-challenges/blob/main/utils/index.d.ts)就容易多了
 
-```tsx
-export type Expect<T extends true> = T
-export type ExpectTrue<T extends true> = T
-export type ExpectFalse<T extends false> = T
-export type IsTrue<T extends true> = T
-export type IsFalse<T extends false> = T
+    ```ts
+    export type Expect<T extends true> = T
+    export type ExpectTrue<T extends true> = T
+    export type ExpectFalse<T extends false> = T
+    export type IsTrue<T extends true> = T
+    export type IsFalse<T extends false> = T
 
-export type Equal<X, Y> =
-  (<T>() => T extends X ? 1 : 2) extends
-  (<T>() => T extends Y ? 1 : 2) ? true : false
-export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
+    export type Equal<X, Y> =
+      (<T>() => T extends X ? 1 : 2) extends
+      (<T>() => T extends Y ? 1 : 2) ? true : false
+    export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
 
-// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
-export type IsAny<T> = 0 extends (1 & T) ? true : false
-export type NotAny<T> = true extends IsAny<T> ? false : true
+    // https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+    export type IsAny<T> = 0 extends (1 & T) ? true : false
+    export type NotAny<T> = true extends IsAny<T> ? false : true
 
-export type Debug<T> = { [K in keyof T]: T[K] }
-export type MergeInsertions<T> =
-  T extends object
-    ? { [K in keyof T]: MergeInsertions<T[K]> }
-    : T
+    export type Debug<T> = { [K in keyof T]: T[K] }
+    export type MergeInsertions<T> =
+      T extends object
+        ? { [K in keyof T]: MergeInsertions<T[K]> }
+        : T
 
-export type Alike<X, Y> = Equal<MergeInsertions<X>, MergeInsertions<Y>>
+    export type Alike<X, Y> = Equal<MergeInsertions<X>, MergeInsertions<Y>>
 
-export type ExpectExtends<VALUE, EXPECTED> = EXPECTED extends VALUE ? true : false
-export type ExpectValidArgs<FUNC extends (...args: any[]) => any, ARGS extends any[]> = ARGS extends Parameters<FUNC>
-  ? true
-  : false
+    export type ExpectExtends<VALUE, EXPECTED> = EXPECTED extends VALUE ? true : false
+    export type ExpectValidArgs<FUNC extends (...args: any[]) => any, ARGS extends any[]> = ARGS extends Parameters<FUNC>
+      ? true
+      : false
 
-export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
-```
+    export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+    ```
 
-以Equal举例
+    以Equal举例
 
-大佬 [@mattmccutchen](https://link.zhihu.com/?target=https%3A//github.com/mattmccutchen) 给出了一个非常精彩的[解决方案](https://link.zhihu.com/?target=https%3A//github.com/microsoft/TypeScript/issues/27024%23issuecomment-421529650)：
+    大佬 [@mattmccutchen](https://link.zhihu.com/?target=https%3A//github.com/mattmccutchen) 给出了一个非常精彩的[解决方案](https://link.zhihu.com/?target=https%3A//github.com/microsoft/TypeScript/issues/27024%23issuecomment-421529650)：
 
-> Here's a solution that makes creative use of the assignability rule for conditional types, which requires that the types after
->
->
-> ```code
-> Here's a solution that makes creative use of the assignability rule for conditional types, which requires that the types after extends be "identical" as that is defined by the checker:
-> ts export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
-> This passes all the tests from the initial description that I was able to run except H, which fails because the definition of "identical" doesn't allow an intersection type to be identical to an object type with the same properties. (I wasn't able to run test E because I don't have the definition of Head.)
-> ```
->
+    > Here's a solution that makes creative use of the assignability rule for conditional types, which requires that the types after
+    >
+    >
+    > ```code
+    > Here's a solution that makes creative use of the assignability rule for conditional types, which requires that the types after extends be "identical" as that is defined by the checker:
+    > ts export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
+    > This passes all the tests from the initial description that I was able to run except H, which fails because the definition of "identical" doesn't allow an intersection type to be identical to an object type with the same properties. (I wasn't able to run test E because I don't have the definition of Head.)
+    > ```
+    >
 
-参考：[https://zhuanlan.zhihu.com/p/597298193](https://zhuanlan.zhihu.com/p/597298193)
+    参考：[https://zhuanlan.zhihu.com/p/597298193](https://zhuanlan.zhihu.com/p/597298193)
 
 ## 面向对象
 
@@ -271,7 +269,7 @@ TypeScript是JavaScript的超集，它在JavaScript的基础上扩展了一些�
 
 下面是一段简单的ts代码，可以很好的表达面向对象的写法。
 
-```tsx
+```ts
 class Animal {
   public name;
   protected a;
@@ -330,7 +328,7 @@ function gen<T extends Animal>(name: T): void {
 
 控制器
 
-```tsx
+```ts
 import { Controller, Get } from '@nestjs/common';
 import { CatsService } from './cats.service';
 import { Cat } from './interfaces/cat.interface';
@@ -348,7 +346,7 @@ export class CatsController {
 
 服务层
 
-```tsx
+```ts
 import { Injectable } from '@nestjs/common';
 import { Cat } from './interfaces/cat.interface';
 
@@ -369,7 +367,7 @@ export class CatsService {
 实现要点
 
 1. 装饰器获取元数据
-2. 通过inversify 或 type地 基于typescript 的ioc 框架，结合元数据实现。
+2. 通过 inversify 或 typedi 等基于typescript的ioc框架，结合元数据实现。
 
 再举个例子，这是java里的测试框架JUnit的写法。
 
@@ -387,53 +385,53 @@ class MyFirstJUnitJupiterTests {
 
 放到ts世界，使用类似于midway的写法。
 
-1、使用注解
+1. 使用注解
 
-```ts
-class MyFirstJUnitJupiterTests {
-  private calculator = new Calculator();
+    ```ts
+    class MyFirstJUnitJupiterTests {
+      private calculator = new Calculator();
 
-  @Test
-  addition() {
-    assert.is(2, this.calculator.add(1, 1));
-  }
-}
-```
+      @Test
+      addition() {
+        assert.is(2, this.calculator.add(1, 1));
+      }
+    }
+    ```
 
-2、使用ioc容器注入
+2. 使用ioc容器注入
 
-```ts
-class MyFirstJUnitJupiterTests {
-  @Inject()
-  calculator: Calculator;
+    ```ts
+    class MyFirstJUnitJupiterTests {
+      @Inject()
+      calculator: Calculator;
 
-  @Test
-  addition() {
-    assert.is(2, this.calculator.add(1, 1));
-  }
-}
-```
+      @Test
+      addition() {
+        assert.is(2, this.calculator.add(1, 1));
+      }
+    }
+    ```
 
-这里的@Test实现如下。
+    这里的@Test实现如下。
 
-```tsx
-export function Test(
-  target: object | any,
-  propertyName: string,
-  descriptor: TypedPropertyDescriptor<any>,
-) {
-  debug(target[propertyName] + descriptor);
+    ```ts
+    export function Test(
+      target: object | any,
+      propertyName: string,
+      descriptor: TypedPropertyDescriptor<any>,
+    ) {
+      debug(target[propertyName] + descriptor);
 
-  //classname
-  const className = target.constructor.name;
+      //classname
+      const className = target.constructor.name;
 
-  if (!cache[className]) cache[className] = {};
-  if (!cache[className][propertyName]) cache[className][propertyName] = {};
+      if (!cache[className]) cache[className] = {};
+      if (!cache[className][propertyName]) cache[className][propertyName] = {};
 
-  cache[className][propertyName]["desc"] = "no display name";
-  cache[className][propertyName]["fn"] = target[propertyName];
-}
-```
+      cache[className][propertyName]["desc"] = "no display name";
+      cache[className][propertyName]["fn"] = target[propertyName];
+    }
+    ```
 
 其实，说白了就是通过装饰器，获取测试用例信息，等执行测试的时候再去调用。
 
@@ -455,11 +453,11 @@ export function Test(
 
 用abstract定义抽象类和抽象方法，抽象类中的抽象方法不包含具体实现并且必须在派生类中实现
 
-1、抽象方法必须在抽象类中
+1. 抽象方法必须在抽象类中
 
-2、抽象类和抽象方法是一个标准，定义标准后，子类中必须包含抽象定义的方法
+2. 抽象类和抽象方法是一个标准，定义标准后，子类中必须包含抽象定义的方法
 
-```tsx
+```ts
 abstract class Father { /* 定义一个抽象方法 */
   public age: number;
   constructor(age: number) {
@@ -480,7 +478,7 @@ class children extends Father {
 
 举例模版模式
 
-```tsx
+```ts
 /**
  * The Abstract Class defines a template method that contains a skeleton of some
  * algorithm, composed of calls to (usually) abstract primitive operations.
@@ -665,9 +663,9 @@ const y: Y = { a: 1, c: 3 };
 
 首先阅读[文档](https://www.typescriptlang.org/docs/)，里面的内容非常丰富，可读性还是非常不错的。
 
-其次，看<https://github.com/gikey/tool-types，虽然它没有star，但更容易理解。>
+其次，看<https://github.com/gikey/tool-types>，虽然它没有star，但更容易理解。
 
-```tsx
+```ts
 /**
  * Intersect
  * @desc 获取两个类型中属性的交集
@@ -697,9 +695,9 @@ export type TupleUnion<T> = T extends Array<infer U> ? U : never;
 
 掌握了这些内容之后，基本类型就过关了。
 
-然后看<https://github.com/sindresorhus/type-fest，比如它的basic>
+然后看<https://github.com/sindresorhus/type-fest>，比如它的basic
 
-```tsx
+```ts
 export type Class<T, Arguments extends unknown[] = any[]> = {
  prototype: T;
  new(...arguments_: Arguments): T;
@@ -724,7 +722,7 @@ export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
 
 再去看其他的就简单多了，比如jsonify。
 
-```tsx
+```ts
 export type Jsonify<T> = IsAny<T> extends true
  ? any
  : T extends PositiveInfinity | NegativeInfinity


### PR DESCRIPTION
您好，这个PR的修改包含以下几部分：

- 代码块渲染修复：
  - 当前的mdbook的代码块似乎不支持tsx格式渲染，因此将本章节代码块tsx的标识改为ts；

- 列表编号格式与缩进统一：
  - 将列表编号格式统一为`<数字>. <内容>`，增加对应内容的缩进，优化阅读体验；

- 链接及笔误修复：
  - 修复了207行以及698行因为笔误出现的链接失效；
  - 370行的“type地”修改为“typedi” （这个我不太确定是不是笔误，猜测可能作者想写的是typedi）

如有错误的地方烦请指正，谢谢！